### PR TITLE
fix: create ZIP archive before uploading release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,13 +111,21 @@ jobs:
         draft: false
         prerelease: false
         
+    - name: Create release archive
+      run: |
+        # Create a ZIP file of the built site
+        cd _site
+        zip -r ../harvard-cv-theme-v${{ steps.version.outputs.new_version }}.zip .
+        cd ..
+        echo "Created release archive: harvard-cv-theme-v${{ steps.version.outputs.new_version }}.zip"
+        
     - name: Upload Release Assets
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./_site/
+        asset_path: ./harvard-cv-theme-v${{ steps.version.outputs.new_version }}.zip
         asset_name: harvard-cv-theme-v${{ steps.version.outputs.new_version }}.zip
         asset_content_type: application/zip
         


### PR DESCRIPTION
- Add step to create ZIP file of built site before upload
- Fix EISDIR error by uploading file instead of directory
- Use zip command to create proper release archive
- Maintain same asset naming convention with version
- Improve release asset creation process